### PR TITLE
CORE UPDATES: backpack UI + inventory. Added new definition to ItemData.

### DIFF
--- a/Components/InventoryComponent.cs
+++ b/Components/InventoryComponent.cs
@@ -23,9 +23,13 @@ public partial class InventoryComponent : BaseComponent
 
     [ExportGroup("Inventory Settings")]
     [Export] public int Capacity = 20;
+    [Export] public string[] StartingItemIds = System.Array.Empty<string>();
+    [Export] public int[] StartingItemCounts = System.Array.Empty<int>();
 
     // 核心数据：槽位列表
     public List<Slot> Slots { get; private set; } = new List<Slot>();
+    private bool _startingItemsApplied;
+    private bool _waitingForDatabase;
 
     // 信号：物品变化时发出，UI 可以监听此信号刷新显示
     [Signal] public delegate void InventoryUpdatedEventHandler();
@@ -40,6 +44,8 @@ public partial class InventoryComponent : BaseComponent
         {
             Slots.Add(new Slot());
         }
+
+        TryApplyStartingItems();
     }
 
     /// <summary>
@@ -164,6 +170,21 @@ public partial class InventoryComponent : BaseComponent
         return total;
     }
 
+    public Slot GetSlot(int index)
+    {
+        if (index < 0 || index >= Slots.Count)
+        {
+            return null;
+        }
+
+        return Slots[index];
+    }
+
+    public bool IsValidSlotIndex(int index)
+    {
+        return index >= 0 && index < Slots.Count;
+    }
+
     /// <summary>
     /// 检查是否有足够的物品
     /// </summary>
@@ -200,5 +221,77 @@ public partial class InventoryComponent : BaseComponent
         }
 
         EmitSignal(SignalName.InventoryUpdated);
+    }
+
+    public override void _ExitTree()
+    {
+        DisconnectDatabaseSignal();
+    }
+
+    private void TryApplyStartingItems()
+    {
+        if (_startingItemsApplied || StartingItemIds.Length == 0)
+        {
+            return;
+        }
+
+        if (ItemDatabase.Instance == null)
+        {
+            return;
+        }
+
+        if (!ItemDatabase.Instance.IsLoaded)
+        {
+            if (!_waitingForDatabase)
+            {
+                ItemDatabase.Instance.DatabaseLoaded += OnItemDatabaseLoaded;
+                _waitingForDatabase = true;
+            }
+
+            return;
+        }
+
+        for (int i = 0; i < StartingItemIds.Length; i++)
+        {
+            string itemId = StartingItemIds[i];
+            if (string.IsNullOrWhiteSpace(itemId))
+            {
+                continue;
+            }
+
+            int count = 1;
+            if (i < StartingItemCounts.Length)
+            {
+                count = System.Math.Max(StartingItemCounts[i], 1);
+            }
+
+            var itemData = ItemDatabase.Instance.GetItem(itemId);
+            if (itemData == null)
+            {
+                GD.PushWarning($"{Name}: 未找到初始物品 {itemId}");
+                continue;
+            }
+
+            AddItem(itemData, count);
+        }
+
+        _startingItemsApplied = true;
+        DisconnectDatabaseSignal();
+    }
+
+    private void OnItemDatabaseLoaded()
+    {
+        TryApplyStartingItems();
+    }
+
+    private void DisconnectDatabaseSignal()
+    {
+        if (!_waitingForDatabase || ItemDatabase.Instance == null)
+        {
+            return;
+        }
+
+        ItemDatabase.Instance.DatabaseLoaded -= OnItemDatabaseLoaded;
+        _waitingForDatabase = false;
     }
 }

--- a/Components/InventoryComponent.cs
+++ b/Components/InventoryComponent.cs
@@ -21,6 +21,12 @@ public partial class InventoryComponent : BaseComponent
         public int RemainingSpace => Item != null ? Item.MaxStack - Count : 0;
     }
 
+    public sealed class SlotSnapshot
+    {
+        public string ItemId;
+        public int Count;
+    }
+
     [ExportGroup("Inventory Settings")]
     [Export] public int Capacity = 20;
     [Export] public string[] StartingItemIds = System.Array.Empty<string>();
@@ -170,6 +176,45 @@ public partial class InventoryComponent : BaseComponent
         return total;
     }
 
+    public bool MoveOrMergeSlot(int fromIndex, int toIndex)
+    {
+        if (!IsValidSlotIndex(fromIndex) || !IsValidSlotIndex(toIndex) || fromIndex == toIndex)
+        {
+            return false;
+        }
+
+        var fromSlot = Slots[fromIndex];
+        var toSlot = Slots[toIndex];
+        if (fromSlot.IsEmpty)
+        {
+            return false;
+        }
+
+        if (CanMergeSlots(fromSlot, toSlot))
+        {
+            int transfer = System.Math.Min(fromSlot.Count, toSlot.RemainingSpace);
+            if (transfer <= 0)
+            {
+                return false;
+            }
+
+            toSlot.Count += transfer;
+            fromSlot.Count -= transfer;
+            if (fromSlot.Count <= 0)
+            {
+                fromSlot.Item = null;
+                fromSlot.Count = 0;
+            }
+        }
+        else
+        {
+            SwapSlotContents(fromSlot, toSlot);
+        }
+
+        EmitSignal(SignalName.InventoryUpdated);
+        return true;
+    }
+
     public Slot GetSlot(int index)
     {
         if (index < 0 || index >= Slots.Count)
@@ -193,6 +238,58 @@ public partial class InventoryComponent : BaseComponent
         return GetItemCount(item) >= amount;
     }
 
+    public List<SlotSnapshot> CaptureSnapshot()
+    {
+        var snapshots = new List<SlotSnapshot>(Slots.Count);
+        foreach (var slot in Slots)
+        {
+            snapshots.Add(new SlotSnapshot
+            {
+                ItemId = slot.Item?.Id ?? string.Empty,
+                Count = slot.IsEmpty ? 0 : slot.Count,
+            });
+        }
+
+        return snapshots;
+    }
+
+    public void RestoreSnapshot(IReadOnlyList<SlotSnapshot> snapshots)
+    {
+        for (int i = 0; i < Slots.Count; i++)
+        {
+            Slots[i].Item = null;
+            Slots[i].Count = 0;
+        }
+
+        if (snapshots == null)
+        {
+            EmitSignal(SignalName.InventoryUpdated);
+            return;
+        }
+
+        for (int i = 0; i < System.Math.Min(Slots.Count, snapshots.Count); i++)
+        {
+            var snapshot = snapshots[i];
+            if (snapshot == null || string.IsNullOrWhiteSpace(snapshot.ItemId) || snapshot.Count <= 0)
+            {
+                continue;
+            }
+
+            var item = ItemDatabase.Instance?.GetItem(snapshot.ItemId);
+            if (item == null)
+            {
+                GD.PushWarning($"{Name}: 恢复背包时未找到物品 {snapshot.ItemId}");
+                continue;
+            }
+
+            Slots[i].Item = item;
+            Slots[i].Count = System.Math.Min(snapshot.Count, item.MaxStack);
+        }
+
+        _startingItemsApplied = true;
+        EmitSignal(SignalName.InventoryUpdated);
+    }
+
     /// <summary>
     /// 查找空槽位
     /// </summary>
@@ -207,6 +304,25 @@ public partial class InventoryComponent : BaseComponent
         }
 
         return null;
+    }
+
+    private static bool CanMergeSlots(Slot fromSlot, Slot toSlot)
+    {
+        return fromSlot.Item != null &&
+               toSlot.Item == fromSlot.Item &&
+               fromSlot.Item.IsStackable &&
+               toSlot.Count < fromSlot.Item.MaxStack;
+    }
+
+    private static void SwapSlotContents(Slot fromSlot, Slot toSlot)
+    {
+        ItemData tempItem = toSlot.Item;
+        int tempCount = toSlot.Count;
+
+        toSlot.Item = fromSlot.Item;
+        toSlot.Count = fromSlot.Count;
+        fromSlot.Item = tempItem;
+        fromSlot.Count = tempCount;
     }
 
     /// <summary>

--- a/Core/BuildingSystem.cs
+++ b/Core/BuildingSystem.cs
@@ -3,6 +3,9 @@ using System;
 
 public partial class BuildingSystem : Node2D
 {
+    [Signal] public delegate void BuildingModeChangedEventHandler(bool isBuildingMode);
+    [Signal] public delegate void ObjectPlacedEventHandler(PackedScene scene, Vector2 position);
+
     [ExportCategory("Config")]
 
     [Export] public TileMapLayer GroundLayer;
@@ -16,6 +19,8 @@ public partial class BuildingSystem : Node2D
 
     private Node2D _previewIllusion; // 预览的虚影
     private bool _isBuildingMode = false;
+    public bool IsBuildingMode => _isBuildingMode;
+    public PackedScene CurrentBuildingTarget => ObjectToPlace;
 
     public override void _Ready()
     {
@@ -39,20 +44,29 @@ public partial class BuildingSystem : Node2D
         // 点击左键放置
         if (@event.IsActionPressed("mouse_left")) // 确保你在 InputMap 里设置了 "mouse_left"
         {
-            PlaceObject();
+            if (PlaceObject())
+            {
+                GetViewport().SetInputAsHandled();
+            }
         }
         
         // 右键取消/旋转（这里先写取消）
         if (@event.IsActionPressed("mouse_right"))
         {
-            _isBuildingMode = false;
-            _previewIllusion.Visible = false;
+            CancelBuildingMode();
+            GetViewport().SetInputAsHandled();
         }
     }
 
     // 核心方法：设置当前要建造的物体
     public void SetBuildingTarget(PackedScene scene)
     {
+        if (scene == null)
+        {
+            CancelBuildingMode();
+            return;
+        }
+
         // 清理旧 Ghost
         if (_previewIllusion != null)
         {
@@ -72,12 +86,28 @@ public partial class BuildingSystem : Node2D
             
             AddChild(_previewIllusion);
             _isBuildingMode = true;
+            UpdateIllusionPosition();
+            EmitSignal(SignalName.BuildingModeChanged, _isBuildingMode);
         }
         else
         {
             GD.PrintErr("BuildingSystem: Trying to place a non-Node2D object!");
             instance.QueueFree();
         }
+    }
+
+    public void CancelBuildingMode()
+    {
+        _isBuildingMode = false;
+        ObjectToPlace = null;
+
+        if (_previewIllusion != null)
+        {
+            _previewIllusion.QueueFree();
+            _previewIllusion = null;
+        }
+
+        EmitSignal(SignalName.BuildingModeChanged, _isBuildingMode);
     }
 
     private void UpdateIllusionPosition()
@@ -93,9 +123,12 @@ public partial class BuildingSystem : Node2D
         _previewIllusion.ZIndex = 1; 
     }
 
-    private void PlaceObject()
+    private bool PlaceObject()
     {
-        if (ObjectToPlace == null) return;
+        if (ObjectToPlace == null)
+        {
+            return false;
+        }
 
         // 真正的实例化
         Node2D newBuilding = ObjectToPlace.Instantiate<Node2D>();
@@ -106,11 +139,13 @@ public partial class BuildingSystem : Node2D
         // 将物体添加到场景中（通常添加到 Y-Sort 节点下，而不是 BuildingSystem 下）
         // 这里假设 GroundLayer 的父节点是主要的 Y-Sort 容器
         ObjectLayer.AddChild(newBuilding);
+        EmitSignal(SignalName.ObjectPlaced, ObjectToPlace, newBuilding.GlobalPosition);
 
         // 可选：放置后是否退出建造模式？
         // _isBuildingMode = false; 
         // _previewIllusion.QueueFree();
         // _previewIllusion = null;
+        return true;
     }
 
     // --- 核心数学逻辑 ---

--- a/Core/GameManager.cs
+++ b/Core/GameManager.cs
@@ -3,6 +3,8 @@ namespace AlongJourney.Core;
 using System;
 using System.Threading.Tasks;
 using Godot;
+using System.Collections.Generic;
+using AlongJourney.Components;
 using AlongJourney.Entities.Player;
 
 public partial class GameManager : Node
@@ -19,6 +21,8 @@ public partial class GameManager : Node
     private uint _playerCollisionLayer;
     private uint _playerCollisionMask;
     private bool _respawnInProgress;
+    private List<InventoryComponent.SlotSnapshot> _cachedInventorySnapshot;
+    private int _cachedActiveSlotIndex = -1;
 
     public override void _Ready()
     {
@@ -31,6 +35,8 @@ public partial class GameManager : Node
     {
         ClearPlayerSubscription();
         _respawnInProgress = false;
+        _cachedInventorySnapshot = null;
+        _cachedActiveSlotIndex = -1;
         CallDeferred(nameof(TryInitializeFromScene));
     }
 
@@ -132,6 +138,7 @@ public partial class GameManager : Node
         }
 
         _respawnInProgress = true;
+        CacheInventoryState(player);
 
         // 先清理信号订阅，避免在删除过程中触发信号
         ClearPlayerSubscription();
@@ -233,6 +240,7 @@ public partial class GameManager : Node
             // 确保新玩家处于正确状态：启用碰撞和受击盒
             player.SetCollisionEnabled(true);
             player.SetHurtboxEnabled(true);
+            RestoreInventoryState(player);
 
             UpdatePhantomCameraFollowTarget(player);
         }
@@ -254,5 +262,30 @@ public partial class GameManager : Node
         if (pcam == null) return;
 
         pcam.Call("set_follow_target", newPlayer);
+    }
+
+    private void CacheInventoryState(Player player)
+    {
+        if (player?.Inventory == null)
+        {
+            _cachedInventorySnapshot = null;
+            _cachedActiveSlotIndex = -1;
+            return;
+        }
+
+        _cachedInventorySnapshot = player.Inventory.CaptureSnapshot();
+        _cachedActiveSlotIndex = player.ActiveSlotIndex;
+    }
+
+    private void RestoreInventoryState(Player player)
+    {
+        if (player?.Inventory == null || _cachedInventorySnapshot == null)
+        {
+            return;
+        }
+
+        player.Inventory.RestoreSnapshot(_cachedInventorySnapshot);
+        int slotIndex = _cachedActiveSlotIndex;
+        player.CallDeferred(nameof(Player.SelectInventorySlot), slotIndex);
     }
 }

--- a/Entities/Environment/Tree.cs
+++ b/Entities/Environment/Tree.cs
@@ -130,8 +130,7 @@ public partial class Tree : TranslucentObstacle, IDamageable, IInteractable
 
     public bool CanInteractWith(Weapon weapon)
     {
-        // 只有斧头可以砍树（未来可以扩展支持其他工具）
-        return weapon is Axe;
+        return weapon != null && weapon.ToolAction == ToolActionType.Chop;
     }
 
     public void OnHoverEnter()

--- a/Entities/Items/Weapon.cs
+++ b/Entities/Items/Weapon.cs
@@ -3,6 +3,7 @@ namespace AlongJourney.Entities.Items;
 using Godot;
 using AlongJourney.Interfaces;
 using AlongJourney.Components;
+using AlongJourney.Resources.Items;
 
 /// <summary>
 /// 武器攻击范围类型
@@ -23,11 +24,13 @@ public abstract partial class Weapon : Node2D
     [ExportGroup("Attack Range")]
     [Export] public AttackRangeType AttackRange = AttackRangeType.Melee;
     [Export] public float MeleeRange = 50f; // 近战攻击范围（像素）
+    [Export] public ToolActionType ToolAction = ToolActionType.None;
 
     [Export] protected HitboxComponent _hitbox;
 
     protected bool _isAttacking = false;
     protected bool _isOnCooldown = false;
+    public ItemData SourceItemData { get; private set; }
 
     public override void _Ready()
     {
@@ -36,6 +39,31 @@ public abstract partial class Weapon : Node2D
 
         if (_hitbox != null)
             _hitbox.DamageAmount = Damage;
+    }
+
+    public virtual void ConfigureFromItem(ItemData sourceItem)
+    {
+        SourceItemData = sourceItem;
+        if (sourceItem == null)
+        {
+            return;
+        }
+
+        ToolAction = sourceItem.ToolAction;
+        if (sourceItem.AttackPower > 0)
+        {
+            Damage = sourceItem.AttackPower;
+        }
+
+        if (sourceItem.UseCooldown > 0f)
+        {
+            Cooldown = sourceItem.UseCooldown;
+        }
+
+        if (_hitbox != null)
+        {
+            _hitbox.DamageAmount = Damage;
+        }
     }
 
     /// <summary>

--- a/Entities/Player/Player.cs
+++ b/Entities/Player/Player.cs
@@ -6,18 +6,35 @@ using AlongJourney.Entities.Items;
 using AlongJourney.Entities.Player.States;
 using AlongJourney.Core;
 using AlongJourney.Components;
+using AlongJourney.Resources.Items;
 
 public partial class Player : Actor
 {
     [Signal]
     public delegate void PlayerDiedEventHandler(Player player);
 
+    [Signal]
+    public delegate void ActiveSlotChangedEventHandler(int slotIndex);
+
+    [Signal]
+    public delegate void ActiveItemChangedEventHandler(ItemData item, int slotIndex);
+
     private Weapon _currentWeapon;
+    private InventoryComponent _inventory;
+    private BuildingSystem _buildingSystem;
+    private ItemData _activeItem;
+    private string _equippedItemId = string.Empty;
+    private int _activeSlotIndex = -1;
 
     [Export] public Marker2D WeaponHolder;
+    [Export] public int HotbarSize = 5;
 
     [ExportGroup("References")]
     [Export] private SelectionManager _selectionManager;
+
+    public InventoryComponent Inventory => _inventory;
+    public ItemData ActiveItem => _activeItem;
+    public int ActiveSlotIndex => _activeSlotIndex;
 
     public override void _Ready()
     {
@@ -33,11 +50,34 @@ public partial class Player : Actor
             HealthComponent.HealthChanged += HandleHealthChanged;
         }
 
-        if (WeaponHolder != null && WeaponHolder.GetChildCount() > 0)
+        _inventory = GetNodeOrNull<InventoryComponent>("Inventory");
+        if (_inventory != null)
         {
-            _currentWeapon = WeaponHolder.GetChild<Weapon>(0);
-            _currentWeapon.AttackFinished += OnWeaponAttackFinished;
+            _inventory.InventoryUpdated += OnInventoryUpdated;
         }
+
+        CallDeferred(nameof(InitializeInventoryState));
+    }
+
+    public override void _ExitTree()
+    {
+        if (HealthComponent != null)
+        {
+            HealthComponent.Died -= HandleDied;
+            HealthComponent.HealthChanged -= HandleHealthChanged;
+        }
+
+        if (_inventory != null)
+        {
+            _inventory.InventoryUpdated -= OnInventoryUpdated;
+        }
+
+        if (_buildingSystem != null)
+        {
+            _buildingSystem.ObjectPlaced -= OnObjectPlaced;
+        }
+
+        DetachCurrentWeapon();
     }
 
     private SelectionManager GetSelectionManager()
@@ -50,6 +90,35 @@ public partial class Player : Actor
         return null;
     }
 
+    public override void _UnhandledInput(InputEvent @event)
+    {
+        if (!IsAlive || @event.IsEcho() || GetTree().Paused)
+        {
+            return;
+        }
+
+        if (HandleHotbarInput(@event))
+        {
+            GetViewport().SetInputAsHandled();
+            return;
+        }
+
+        if (!@event.IsActionPressed("attack"))
+        {
+            return;
+        }
+
+        if (_activeItem != null && _activeItem.IsPlaceableItem())
+        {
+            return;
+        }
+
+        if (TryUseActiveItem())
+        {
+            GetViewport().SetInputAsHandled();
+        }
+    }
+
     public override void _PhysicsProcess(double delta)
     {
         if (!IsAlive)
@@ -58,11 +127,6 @@ public partial class Player : Actor
         }
 
         HandleWeaponAiming();
-
-        if (Input.IsActionJustPressed("attack"))
-        {
-            TryStartAttack();
-        }
 
         // MovementComponent 和 PlayerInputComponent 会自动处理移动
         base._PhysicsProcess(delta);
@@ -102,11 +166,33 @@ public partial class Player : Actor
         }
     }
 
-    private void TryStartAttack()
+    private void InitializeInventoryState()
+    {
+        _buildingSystem = ResolveBuildingSystem();
+        if (_buildingSystem != null)
+        {
+            _buildingSystem.ObjectPlaced += OnObjectPlaced;
+        }
+
+        int initialSlot = FindFirstOccupiedSlot();
+        if (initialSlot < 0)
+        {
+            initialSlot = 0;
+        }
+
+        SetActiveSlot(initialSlot, emitSignals: true);
+    }
+
+    private BuildingSystem ResolveBuildingSystem()
+    {
+        return GetTree().CurrentScene?.GetNodeOrNull<BuildingSystem>("BuildingSystem");
+    }
+
+    private bool TryStartAttack()
     {
         if (_currentWeapon == null)
         {
-            return;
+            return false;
         }
 
         // 优先尝试攻击选中的目标
@@ -122,7 +208,7 @@ public partial class Player : Actor
                     if (_currentWeapon.AttackTarget(hoveredTarget, GlobalPosition))
                     {
                         SetBlackboardValue(Actor.BlackboardKeys.IsAttacking, true);
-                        return;
+                        return true;
                     }
                 }
             }
@@ -133,7 +219,10 @@ public partial class Player : Actor
         if (_currentWeapon.Attack(mouseDir))
         {
             SetBlackboardValue(Actor.BlackboardKeys.IsAttacking, true);
+            return true;
         }
+
+        return false;
     }
 
     private void HandleWeaponAiming()
@@ -175,6 +264,311 @@ public partial class Player : Actor
             // 清除攻击标志，状态机会自动转换回 Idle/Run
             SetBlackboardValue(Actor.BlackboardKeys.IsAttacking, false);
         }
+    }
+
+    private bool TryUseActiveItem()
+    {
+        if (_activeItem != null && _activeItem.IsConsumableItem())
+        {
+            return TryConsumeActiveItem();
+        }
+
+        return TryStartAttack();
+    }
+
+    private bool TryConsumeActiveItem()
+    {
+        if (_inventory == null || _activeItem == null || HealthComponent == null)
+        {
+            return false;
+        }
+
+        if (_activeItem.HealAmount <= 0 || HealthComponent.CurrentHealth >= HealthComponent.MaxHealth)
+        {
+            return false;
+        }
+
+        int removed = _inventory.RemoveItem(_activeItem, 1);
+        if (removed <= 0)
+        {
+            return false;
+        }
+
+        HealthComponent.Heal(_activeItem.HealAmount);
+        RefreshActiveItemState();
+        return true;
+    }
+
+    private bool HandleHotbarInput(InputEvent @event)
+    {
+        if (_inventory == null)
+        {
+            return false;
+        }
+
+        if (@event is InputEventKey keyEvent && keyEvent.Pressed && !keyEvent.Echo)
+        {
+            int slotIndex = GetHotbarSlotFromKey(keyEvent.Keycode);
+            if (slotIndex >= 0)
+            {
+                return SelectHotbarSlot(slotIndex);
+            }
+        }
+
+        if (@event is InputEventMouseButton mouseButton && mouseButton.Pressed)
+        {
+            if (mouseButton.ButtonIndex == MouseButton.WheelUp)
+            {
+                CycleHotbarSelection(-1);
+                return true;
+            }
+
+            if (mouseButton.ButtonIndex == MouseButton.WheelDown)
+            {
+                CycleHotbarSelection(1);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private int GetHotbarSlotFromKey(Key keycode)
+    {
+        return keycode switch
+        {
+            Key.Key1 => 0,
+            Key.Key2 => 1,
+            Key.Key3 => 2,
+            Key.Key4 => 3,
+            Key.Key5 => 4,
+            Key.Key6 => 5,
+            Key.Key7 => 6,
+            Key.Key8 => 7,
+            Key.Key9 => 8,
+            Key.Key0 => 9,
+            _ => -1
+        };
+    }
+
+    public bool SelectHotbarSlot(int slotIndex)
+    {
+        if (slotIndex < 0 || slotIndex >= GetHotbarSlotCount())
+        {
+            return false;
+        }
+
+        return SetActiveSlot(slotIndex, emitSignals: true);
+    }
+
+    public bool SelectInventorySlot(int slotIndex)
+    {
+        return SetActiveSlot(slotIndex, emitSignals: true);
+    }
+
+    public int GetHotbarSlotCount()
+    {
+        if (_inventory == null)
+        {
+            return HotbarSize;
+        }
+
+        return Mathf.Min(HotbarSize, _inventory.Slots.Count);
+    }
+
+    public void CycleHotbarSelection(int direction)
+    {
+        int hotbarCount = GetHotbarSlotCount();
+        if (hotbarCount <= 0)
+        {
+            return;
+        }
+
+        int currentSlot = Mathf.Clamp(_activeSlotIndex, 0, hotbarCount - 1);
+        int nextSlot = (currentSlot + direction + hotbarCount) % hotbarCount;
+        SetActiveSlot(nextSlot, emitSignals: true);
+    }
+
+    private bool SetActiveSlot(int slotIndex, bool emitSignals)
+    {
+        if (_inventory == null)
+        {
+            return false;
+        }
+
+        if (_inventory.Slots.Count == 0)
+        {
+            slotIndex = -1;
+        }
+        else
+        {
+            slotIndex = Mathf.Clamp(slotIndex, 0, _inventory.Slots.Count - 1);
+        }
+
+        _activeSlotIndex = slotIndex;
+        RefreshActiveItemState(emitSignals);
+        return true;
+    }
+
+    private void RefreshActiveItemState(bool emitSignals = true)
+    {
+        _activeItem = _inventory?.GetSlot(_activeSlotIndex)?.Item;
+        ApplySelectedItemMode();
+
+        if (emitSignals)
+        {
+            EmitSignal(SignalName.ActiveSlotChanged, _activeSlotIndex);
+            EmitSignal(SignalName.ActiveItemChanged, _activeItem, _activeSlotIndex);
+        }
+    }
+
+    private void ApplySelectedItemMode()
+    {
+        if (_buildingSystem == null || !IsInstanceValid(_buildingSystem))
+        {
+            _buildingSystem = ResolveBuildingSystem();
+            if (_buildingSystem != null)
+            {
+                _buildingSystem.ObjectPlaced -= OnObjectPlaced;
+                _buildingSystem.ObjectPlaced += OnObjectPlaced;
+            }
+        }
+
+        if (_activeItem != null && _activeItem.IsToolItem())
+        {
+            _buildingSystem?.CancelBuildingMode();
+            EquipToolFromItem(_activeItem);
+            return;
+        }
+
+        DetachCurrentWeapon();
+
+        if (_activeItem != null && _activeItem.IsPlaceableItem())
+        {
+            _buildingSystem?.SetBuildingTarget(_activeItem.Prefab);
+            return;
+        }
+
+        _buildingSystem?.CancelBuildingMode();
+    }
+
+    private void EquipToolFromItem(ItemData item)
+    {
+        if (item == null || item.EquipScene == null || WeaponHolder == null)
+        {
+            DetachCurrentWeapon();
+            return;
+        }
+
+        if (_currentWeapon != null && _equippedItemId == item.Id && IsInstanceValid(_currentWeapon))
+        {
+            _currentWeapon.Position = item.EquipOffset;
+            _currentWeapon.ConfigureFromItem(item);
+            return;
+        }
+
+        DetachCurrentWeapon();
+
+        Node instance = item.EquipScene.Instantiate();
+        if (instance is not Weapon weapon)
+        {
+            GD.PushError($"Player: 物品 {item.Id} 的 EquipScene 不是 Weapon");
+            instance.QueueFree();
+            return;
+        }
+
+        WeaponHolder.AddChild(weapon);
+        weapon.Position = item.EquipOffset;
+        weapon.ConfigureFromItem(item);
+        weapon.AttackFinished += OnWeaponAttackFinished;
+        _currentWeapon = weapon;
+        _equippedItemId = item.Id;
+    }
+
+    private void DetachCurrentWeapon()
+    {
+        if (_currentWeapon != null)
+        {
+            _currentWeapon.AttackFinished -= OnWeaponAttackFinished;
+            _currentWeapon.QueueFree();
+            _currentWeapon = null;
+        }
+
+        _equippedItemId = string.Empty;
+    }
+
+    private void OnInventoryUpdated()
+    {
+        if (_inventory == null)
+        {
+            return;
+        }
+
+        if (_inventory.Slots.Count == 0)
+        {
+            _activeSlotIndex = -1;
+        }
+        else if (_activeSlotIndex < 0)
+        {
+            _activeSlotIndex = 0;
+        }
+        else if (_activeSlotIndex >= _inventory.Slots.Count)
+        {
+            _activeSlotIndex = _inventory.Slots.Count - 1;
+        }
+
+        RefreshActiveItemState();
+    }
+
+    private void OnObjectPlaced(PackedScene scene, Vector2 position)
+    {
+        if (_inventory == null || _activeItem == null || scene == null)
+        {
+            return;
+        }
+
+        if (!_activeItem.IsPlaceableItem() || _activeItem.Prefab != scene)
+        {
+            return;
+        }
+
+        int removed = _inventory.RemoveItem(_activeItem, 1);
+        if (removed <= 0)
+        {
+            return;
+        }
+
+        if (_inventory.GetItemCount(_activeItem) > 0)
+        {
+            RefreshActiveItemState();
+            return;
+        }
+
+        int nextSlot = FindFirstOccupiedSlot();
+        if (nextSlot < 0)
+        {
+            nextSlot = 0;
+        }
+
+        SetActiveSlot(nextSlot, emitSignals: true);
+    }
+
+    private int FindFirstOccupiedSlot()
+    {
+        if (_inventory == null)
+        {
+            return -1;
+        }
+
+        for (int i = 0; i < _inventory.Slots.Count; i++)
+        {
+            if (!_inventory.Slots[i].IsEmpty)
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
 }

--- a/Entities/Player/player.tscn
+++ b/Entities/Player/player.tscn
@@ -9,7 +9,6 @@
 [ext_resource type="Script" uid="uid://bq7kokxio5iif" path="res://Components/AnimationController.cs" id="6_d2wvv"]
 [ext_resource type="Script" uid="uid://cdpj2qq7mig3y" path="res://Components/HurtboxComponent.cs" id="6_ur7pv"]
 [ext_resource type="Script" uid="uid://c36x6ft31psxx" path="res://Components/HealthComponent.cs" id="7_y4r1p"]
-[ext_resource type="PackedScene" uid="uid://dambflx8sgsb8" path="res://Entities/Items/axe.tscn" id="9_ur7pv"]
 [ext_resource type="Script" uid="uid://bwlybm005er1a" path="res://Components/HitEffectComponent.cs" id="10_y4r1p"]
 [ext_resource type="Script" uid="uid://bmgna558so5yc" path="res://Components/MovementComponent.cs" id="13_jej6c"]
 [ext_resource type="Script" uid="uid://bl64fw2mufqhi" path="res://Components/PlayerInputComponent.cs" id="14_f1ej7"]
@@ -393,10 +392,6 @@ shape = SubResource("CapsuleShape2D_3v2ag")
 y_sort_enabled = true
 position = Vector2(0, -8)
 
-[node name="Axe" parent="WeaponPivot" unique_id=971752055 instance=ExtResource("9_ur7pv")]
-position = Vector2(4, 0)
-Damage = 15
-
 [node name="CoreComponents" type="Node" parent="." unique_id=712897908]
 
 [node name="Health" type="Node" parent="CoreComponents" unique_id=1499330659]
@@ -452,3 +447,5 @@ script = ExtResource("23_4ni07")
 
 [node name="Inventory" type="Node" parent="." unique_id=2118170939]
 script = ExtResource("15_a8ls1")
+StartingItemIds = PackedStringArray("axe", "table")
+StartingItemCounts = PackedInt32Array(1, 3)

--- a/UI/Inventory/GameInventoryUI.cs
+++ b/UI/Inventory/GameInventoryUI.cs
@@ -19,8 +19,9 @@ public partial class GameInventoryUI : CanvasLayer
     private PanelContainer _inventoryPanel;
     private GridContainer _inventoryGrid;
     private Label _selectedItemLabel;
-    private readonly List<Button> _hotbarButtons = new();
-    private readonly List<Button> _inventoryButtons = new();
+    private Label _dragHintLabel;
+    private readonly List<InventorySlotView> _hotbarButtons = new();
+    private readonly List<InventorySlotView> _inventoryButtons = new();
     private double _rebindCooldown;
 
     public override void _Ready()
@@ -80,6 +81,15 @@ public partial class GameInventoryUI : CanvasLayer
         _selectedItemLabel.SetAnchorsPreset(Control.LayoutPreset.TopLeft);
         _selectedItemLabel.Position = new Vector2(20, 20);
         _root.AddChild(_selectedItemLabel);
+
+        _dragHintLabel = new Label
+        {
+            Text = "拖拽槽位可交换或合并物品",
+            MouseFilter = Control.MouseFilterEnum.Ignore,
+        };
+        _dragHintLabel.SetAnchorsPreset(Control.LayoutPreset.TopLeft);
+        _dragHintLabel.Position = new Vector2(20, 44);
+        _root.AddChild(_dragHintLabel);
 
         _inventoryPanel = new PanelContainer
         {
@@ -207,7 +217,9 @@ public partial class GameInventoryUI : CanvasLayer
         {
             int slotIndex = i;
             var button = CreateSlotButton(new Vector2(88, 72));
-            button.Pressed += () => _player?.SelectHotbarSlot(slotIndex);
+            button.Configure(slotIndex, true, _inventory?.GetSlot(slotIndex));
+            button.SlotPressed += OnSlotPressed;
+            button.SlotDropped += OnSlotDropped;
             _hotbarButtons.Add(button);
             _hotbarRow.AddChild(button);
         }
@@ -217,15 +229,17 @@ public partial class GameInventoryUI : CanvasLayer
         {
             int slotIndex = i;
             var button = CreateSlotButton(new Vector2(92, 72));
-            button.Pressed += () => _player?.SelectInventorySlot(slotIndex);
+            button.Configure(slotIndex, false, _inventory?.GetSlot(slotIndex));
+            button.SlotPressed += OnSlotPressed;
+            button.SlotDropped += OnSlotDropped;
             _inventoryButtons.Add(button);
             _inventoryGrid.AddChild(button);
         }
     }
 
-    private static Button CreateSlotButton(Vector2 minSize)
+    private static InventorySlotView CreateSlotButton(Vector2 minSize)
     {
-        return new Button
+        return new InventorySlotView
         {
             CustomMinimumSize = minSize,
             ClipText = true,
@@ -238,7 +252,7 @@ public partial class GameInventoryUI : CanvasLayer
         };
     }
 
-    private static void ClearButtons(List<Button> buttons, Node parent)
+    private static void ClearButtons(List<InventorySlotView> buttons, Node parent)
     {
         buttons.Clear();
 
@@ -319,6 +333,11 @@ public partial class GameInventoryUI : CanvasLayer
 
     private void UpdateButtonVisual(Button button, InventoryComponent.Slot slot, int slotIndex, bool isHotbar)
     {
+        if (button is InventorySlotView slotView)
+        {
+            slotView.Configure(slotIndex, isHotbar, slot);
+        }
+
         bool isSelected = _player != null && _player.ActiveSlotIndex == slotIndex;
         button.Modulate = isSelected ? new Color(1.2f, 1.15f, 0.8f) : Colors.White;
         button.Icon = slot?.Item?.Icon;
@@ -334,5 +353,23 @@ public partial class GameInventoryUI : CanvasLayer
         string countText = slot.Item.IsStackable ? $"x{slot.Count}" : "Ready";
         button.Text = $"{prefix}\n{slot.Item.Name}\n{countText}";
         button.TooltipText = slot.Item.GetFullDescription();
+    }
+
+    private void OnSlotPressed(int slotIndex)
+    {
+        _player?.SelectInventorySlot(slotIndex);
+    }
+
+    private void OnSlotDropped(int fromSlotIndex, int toSlotIndex)
+    {
+        if (_inventory == null)
+        {
+            return;
+        }
+
+        if (_inventory.MoveOrMergeSlot(fromSlotIndex, toSlotIndex))
+        {
+            _player?.SelectInventorySlot(toSlotIndex);
+        }
     }
 }

--- a/UI/Inventory/GameInventoryUI.cs
+++ b/UI/Inventory/GameInventoryUI.cs
@@ -1,0 +1,338 @@
+namespace AlongJourney.UI.Inventory;
+
+using System.Collections.Generic;
+using Godot;
+using AlongJourney.Components;
+using AlongJourney.Core;
+using AlongJourney.Entities.Player;
+using AlongJourney.Resources.Items;
+
+public partial class GameInventoryUI : CanvasLayer
+{
+    private const double RebindIntervalSeconds = 0.5d;
+
+    private Player _player;
+    private InventoryComponent _inventory;
+    private Control _root;
+    private PanelContainer _hotbarPanel;
+    private HBoxContainer _hotbarRow;
+    private PanelContainer _inventoryPanel;
+    private GridContainer _inventoryGrid;
+    private Label _selectedItemLabel;
+    private readonly List<Button> _hotbarButtons = new();
+    private readonly List<Button> _inventoryButtons = new();
+    private double _rebindCooldown;
+
+    public override void _Ready()
+    {
+        Layer = 64;
+        BuildUi();
+        RebindToCurrentPlayer();
+        RefreshUi();
+    }
+
+    public override void _Process(double delta)
+    {
+        if (IsBoundPlayerValid())
+        {
+            return;
+        }
+
+        _rebindCooldown -= delta;
+        if (_rebindCooldown > 0d)
+        {
+            return;
+        }
+
+        RebindToCurrentPlayer();
+    }
+
+    public override void _UnhandledInput(InputEvent @event)
+    {
+        if (@event is not InputEventKey keyEvent || !keyEvent.Pressed || keyEvent.Echo)
+        {
+            return;
+        }
+
+        if (keyEvent.Keycode != Key.I && keyEvent.Keycode != Key.Tab)
+        {
+            return;
+        }
+
+        ToggleInventory();
+        GetViewport().SetInputAsHandled();
+    }
+
+    private void BuildUi()
+    {
+        _root = new Control
+        {
+            MouseFilter = Control.MouseFilterEnum.Ignore,
+        };
+        _root.SetAnchorsPreset(Control.LayoutPreset.FullRect);
+        AddChild(_root);
+
+        _selectedItemLabel = new Label
+        {
+            Text = "未选择物品",
+            MouseFilter = Control.MouseFilterEnum.Ignore,
+        };
+        _selectedItemLabel.SetAnchorsPreset(Control.LayoutPreset.TopLeft);
+        _selectedItemLabel.Position = new Vector2(20, 20);
+        _root.AddChild(_selectedItemLabel);
+
+        _inventoryPanel = new PanelContainer
+        {
+            Visible = false,
+            MouseFilter = Control.MouseFilterEnum.Stop,
+            CustomMinimumSize = new Vector2(420, 360),
+        };
+        _inventoryPanel.SetAnchorsPreset(Control.LayoutPreset.TopRight);
+        _inventoryPanel.OffsetLeft = -460;
+        _inventoryPanel.OffsetTop = 20;
+        _inventoryPanel.OffsetRight = -20;
+        _inventoryPanel.OffsetBottom = 420;
+        _root.AddChild(_inventoryPanel);
+
+        var inventoryMargin = new MarginContainer();
+        inventoryMargin.AddThemeConstantOverride("margin_left", 12);
+        inventoryMargin.AddThemeConstantOverride("margin_top", 12);
+        inventoryMargin.AddThemeConstantOverride("margin_right", 12);
+        inventoryMargin.AddThemeConstantOverride("margin_bottom", 12);
+        _inventoryPanel.AddChild(inventoryMargin);
+
+        var inventoryVBox = new VBoxContainer();
+        inventoryVBox.AddThemeConstantOverride("separation", 8);
+        inventoryMargin.AddChild(inventoryVBox);
+
+        var title = new Label
+        {
+            Text = "Backpack",
+            HorizontalAlignment = HorizontalAlignment.Center,
+        };
+        inventoryVBox.AddChild(title);
+
+        _inventoryGrid = new GridContainer
+        {
+            Columns = 4,
+        };
+        _inventoryGrid.AddThemeConstantOverride("h_separation", 8);
+        _inventoryGrid.AddThemeConstantOverride("v_separation", 8);
+        inventoryVBox.AddChild(_inventoryGrid);
+
+        _hotbarPanel = new PanelContainer
+        {
+            MouseFilter = Control.MouseFilterEnum.Stop,
+            CustomMinimumSize = new Vector2(480, 96),
+        };
+        _hotbarPanel.SetAnchorsPreset(Control.LayoutPreset.BottomWide);
+        _hotbarPanel.OffsetLeft = 320;
+        _hotbarPanel.OffsetTop = -120;
+        _hotbarPanel.OffsetRight = -320;
+        _hotbarPanel.OffsetBottom = -20;
+        _root.AddChild(_hotbarPanel);
+
+        var hotbarMargin = new MarginContainer();
+        hotbarMargin.AddThemeConstantOverride("margin_left", 8);
+        hotbarMargin.AddThemeConstantOverride("margin_top", 8);
+        hotbarMargin.AddThemeConstantOverride("margin_right", 8);
+        hotbarMargin.AddThemeConstantOverride("margin_bottom", 8);
+        _hotbarPanel.AddChild(hotbarMargin);
+
+        _hotbarRow = new HBoxContainer
+        {
+            Alignment = BoxContainer.AlignmentMode.Center,
+        };
+        _hotbarRow.AddThemeConstantOverride("separation", 8);
+        hotbarMargin.AddChild(_hotbarRow);
+    }
+
+    private bool IsBoundPlayerValid()
+    {
+        return _player != null && IsInstanceValid(_player) && _player.IsInsideTree();
+    }
+
+    private void RebindToCurrentPlayer()
+    {
+        var nextPlayer = GetTree().GetFirstNodeInGroup(GameConstants.PlayerGroupName) as Player;
+        if (_player == nextPlayer && IsBoundPlayerValid())
+        {
+            return;
+        }
+
+        DisconnectCurrentPlayer();
+        _player = nextPlayer;
+        _inventory = _player?.Inventory;
+        _rebindCooldown = RebindIntervalSeconds;
+
+        if (_player != null)
+        {
+            _player.ActiveSlotChanged += OnActiveSelectionChanged;
+            _player.ActiveItemChanged += OnActiveItemChanged;
+        }
+
+        if (_inventory != null)
+        {
+            _inventory.InventoryUpdated += OnInventoryUpdated;
+        }
+
+        RebuildSlotButtons();
+        RefreshUi();
+    }
+
+    private void DisconnectCurrentPlayer()
+    {
+        if (_player != null)
+        {
+            _player.ActiveSlotChanged -= OnActiveSelectionChanged;
+            _player.ActiveItemChanged -= OnActiveItemChanged;
+        }
+
+        if (_inventory != null)
+        {
+            _inventory.InventoryUpdated -= OnInventoryUpdated;
+        }
+
+        _player = null;
+        _inventory = null;
+    }
+
+    private void RebuildSlotButtons()
+    {
+        ClearButtons(_hotbarButtons, _hotbarRow);
+        ClearButtons(_inventoryButtons, _inventoryGrid);
+
+        int hotbarCount = _player?.GetHotbarSlotCount() ?? 0;
+        for (int i = 0; i < hotbarCount; i++)
+        {
+            int slotIndex = i;
+            var button = CreateSlotButton(new Vector2(88, 72));
+            button.Pressed += () => _player?.SelectHotbarSlot(slotIndex);
+            _hotbarButtons.Add(button);
+            _hotbarRow.AddChild(button);
+        }
+
+        int inventoryCount = _inventory?.Slots.Count ?? 0;
+        for (int i = 0; i < inventoryCount; i++)
+        {
+            int slotIndex = i;
+            var button = CreateSlotButton(new Vector2(92, 72));
+            button.Pressed += () => _player?.SelectInventorySlot(slotIndex);
+            _inventoryButtons.Add(button);
+            _inventoryGrid.AddChild(button);
+        }
+    }
+
+    private static Button CreateSlotButton(Vector2 minSize)
+    {
+        return new Button
+        {
+            CustomMinimumSize = minSize,
+            ClipText = true,
+            TextOverrunBehavior = TextServer.OverrunBehavior.TrimEllipsis,
+            IconAlignment = HorizontalAlignment.Center,
+            VerticalIconAlignment = VerticalAlignment.Top,
+            Alignment = HorizontalAlignment.Center,
+            Text = "Empty",
+            FocusMode = Control.FocusModeEnum.None,
+        };
+    }
+
+    private static void ClearButtons(List<Button> buttons, Node parent)
+    {
+        buttons.Clear();
+
+        foreach (Node child in parent.GetChildren())
+        {
+            child.QueueFree();
+        }
+    }
+
+    private void ToggleInventory()
+    {
+        _inventoryPanel.Visible = !_inventoryPanel.Visible;
+    }
+
+    private void OnInventoryUpdated()
+    {
+        if (_inventoryButtons.Count != (_inventory?.Slots.Count ?? 0) ||
+            _hotbarButtons.Count != (_player?.GetHotbarSlotCount() ?? 0))
+        {
+            RebuildSlotButtons();
+        }
+
+        RefreshUi();
+    }
+
+    private void OnActiveSelectionChanged(int slotIndex)
+    {
+        RefreshUi();
+    }
+
+    private void OnActiveItemChanged(ItemData item, int slotIndex)
+    {
+        RefreshUi();
+    }
+
+    private void RefreshUi()
+    {
+        RefreshSelectedItemLabel();
+        RefreshHotbarButtons();
+        RefreshInventoryButtons();
+    }
+
+    private void RefreshSelectedItemLabel()
+    {
+        if (_player == null || _inventory == null)
+        {
+            _selectedItemLabel.Text = "等待玩家生成...";
+            return;
+        }
+
+        var activeItem = _player.ActiveItem;
+        if (activeItem == null)
+        {
+            _selectedItemLabel.Text = $"当前槽位: {_player.ActiveSlotIndex + 1}";
+            return;
+        }
+
+        _selectedItemLabel.Text = $"当前物品: {activeItem.Name}  x{_inventory.GetItemCount(activeItem)}";
+    }
+
+    private void RefreshHotbarButtons()
+    {
+        for (int i = 0; i < _hotbarButtons.Count; i++)
+        {
+            var slot = _inventory?.GetSlot(i);
+            UpdateButtonVisual(_hotbarButtons[i], slot, i, true);
+        }
+    }
+
+    private void RefreshInventoryButtons()
+    {
+        for (int i = 0; i < _inventoryButtons.Count; i++)
+        {
+            var slot = _inventory?.GetSlot(i);
+            UpdateButtonVisual(_inventoryButtons[i], slot, i, false);
+        }
+    }
+
+    private void UpdateButtonVisual(Button button, InventoryComponent.Slot slot, int slotIndex, bool isHotbar)
+    {
+        bool isSelected = _player != null && _player.ActiveSlotIndex == slotIndex;
+        button.Modulate = isSelected ? new Color(1.2f, 1.15f, 0.8f) : Colors.White;
+        button.Icon = slot?.Item?.Icon;
+
+        string prefix = isHotbar ? $"[{slotIndex + 1}]" : $"#{slotIndex + 1}";
+        if (slot == null || slot.IsEmpty)
+        {
+            button.Text = $"{prefix}\nEmpty";
+            button.TooltipText = "空槽位";
+            return;
+        }
+
+        string countText = slot.Item.IsStackable ? $"x{slot.Count}" : "Ready";
+        button.Text = $"{prefix}\n{slot.Item.Name}\n{countText}";
+        button.TooltipText = slot.Item.GetFullDescription();
+    }
+}

--- a/UI/Inventory/InventorySlotView.cs
+++ b/UI/Inventory/InventorySlotView.cs
@@ -1,0 +1,87 @@
+namespace AlongJourney.UI.Inventory;
+
+using Godot;
+using AlongJourney.Components;
+
+public partial class InventorySlotView : Button
+{
+    [Signal] public delegate void SlotPressedEventHandler(int slotIndex);
+    [Signal] public delegate void SlotDroppedEventHandler(int fromSlotIndex, int toSlotIndex);
+
+    public int SlotIndex { get; private set; } = -1;
+    public bool IsHotbarSlot { get; private set; }
+    public InventoryComponent.Slot SlotData { get; private set; }
+
+    public void Configure(int slotIndex, bool isHotbarSlot, InventoryComponent.Slot slotData)
+    {
+        SlotIndex = slotIndex;
+        IsHotbarSlot = isHotbarSlot;
+        SlotData = slotData;
+    }
+
+    public override void _GuiInput(InputEvent @event)
+    {
+        base._GuiInput(@event);
+
+        if (@event is InputEventMouseButton mouseButton &&
+            mouseButton.ButtonIndex == MouseButton.Left &&
+            mouseButton.Pressed)
+        {
+            EmitSignal(SignalName.SlotPressed, SlotIndex);
+        }
+    }
+
+    public override Variant _GetDragData(Vector2 atPosition)
+    {
+        if (SlotData == null || SlotData.IsEmpty)
+        {
+            return default;
+        }
+
+        var preview = new PanelContainer();
+        preview.CustomMinimumSize = new Vector2(96, 72);
+        var label = new Label
+        {
+            Text = $"{SlotData.Item.Name}\nx{SlotData.Count}",
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        preview.AddChild(label);
+        SetDragPreview(preview);
+
+        var data = new Godot.Collections.Dictionary<string, Variant>
+        {
+            { "from_slot", SlotIndex },
+        };
+        return Variant.CreateFrom(data);
+    }
+
+    public override bool _CanDropData(Vector2 atPosition, Variant data)
+    {
+        if (SlotIndex < 0)
+        {
+            return false;
+        }
+
+        var dictionary = data.AsGodotDictionary();
+        if (!dictionary.ContainsKey("from_slot"))
+        {
+            return false;
+        }
+
+        int fromSlot = (int)dictionary["from_slot"];
+        return fromSlot >= 0 && fromSlot != SlotIndex;
+    }
+
+    public override void _DropData(Vector2 atPosition, Variant data)
+    {
+        var dictionary = data.AsGodotDictionary();
+        if (!dictionary.ContainsKey("from_slot"))
+        {
+            return;
+        }
+
+        int fromSlot = (int)dictionary["from_slot"];
+        EmitSignal(SignalName.SlotDropped, fromSlot, SlotIndex);
+    }
+}

--- a/UI/Inventory/game_inventory_ui.tscn
+++ b/UI/Inventory/game_inventory_ui.tscn
@@ -1,0 +1,6 @@
+[gd_scene format=3]
+
+[ext_resource type="Script" path="res://UI/Inventory/GameInventoryUI.cs" id="1_ui"]
+
+[node name="GameInventoryUI" type="CanvasLayer"]
+script = ExtResource("1_ui")

--- a/basic.tscn
+++ b/basic.tscn
@@ -10,8 +10,8 @@
 [ext_resource type="PackedScene" uid="uid://dgl0m2dggs3ef" path="res://Entities/Environment/rock.tscn" id="9_rv4ag"]
 [ext_resource type="PackedScene" uid="uid://df01wn734v1rp" path="res://Entities/Environment/tree_0.tscn" id="10_7t5rf"]
 [ext_resource type="PackedScene" uid="uid://bjmid78a1unwj" path="res://Entities/Enemies/ghost.tscn" id="11_cmjf8"]
-[ext_resource type="PackedScene" uid="uid://cqblmfm7y7nr8" path="res://Entities/Environment/table.tscn" id="11_d7s5t"]
 [ext_resource type="Script" uid="uid://dvq8ka8plnyco" path="res://Core/BuildingSystem.cs" id="12_t15vj"]
+[ext_resource type="PackedScene" path="res://UI/Inventory/game_inventory_ui.tscn" id="13_ui"]
 
 [sub_resource type="Resource" id="Resource_tglyx"]
 script = ExtResource("4_o6kd5")
@@ -235,4 +235,5 @@ script = ExtResource("12_t15vj")
 GroundLayer = NodePath("../GoundLayer")
 ObjectLayer = NodePath("../ObjectLayer")
 Subdivisions = 1
-ObjectToPlace = ExtResource("11_d7s5t")
+
+[node name="GameInventoryUI" parent="." instance=ExtResource("13_ui")]

--- a/resources/items/ItemData.cs
+++ b/resources/items/ItemData.cs
@@ -30,6 +30,29 @@ public enum ItemRarity
 }
 
 /// <summary>
+/// 物品使用模式
+/// </summary>
+public enum ItemUseMode
+{
+    None,
+    Tool,
+    Placeable,
+    Consumable
+}
+
+/// <summary>
+/// 工具行为类型，用于数据驱动交互
+/// </summary>
+public enum ToolActionType
+{
+    None,
+    Chop,
+    Mine,
+    Dig,
+    Harvest
+}
+
+/// <summary>
 /// 物品数据资源，使用 Godot Resource 系统
 /// 在编辑器中创建 .tres 文件来定义物品属性
 /// </summary>
@@ -65,7 +88,11 @@ public partial class ItemData : Resource
     [Export] public bool HasUseEffect = false;
     [Export] public int HealAmount = 0;       // 使用后恢复的生命值
     [Export] public float UseCooldown = 0f;  // 使用冷却时间（秒）
-    
+    [Export] public ItemUseMode UseMode = ItemUseMode.None;
+    [Export] public ToolActionType ToolAction = ToolActionType.None;
+    [Export] public PackedScene EquipScene;   // 装备到手上的工具/武器场景
+    [Export] public Vector2 EquipOffset = Vector2.Zero;
+
     [ExportGroup("Advanced")]
     [Export] public PackedScene Prefab;       // 物品预制体（如建筑、特殊物品）
     // 注意：Godot 不支持直接导出 Dictionary，如需自定义数据请使用其他方式
@@ -108,6 +135,18 @@ public partial class ItemData : Resource
             errorMessage = "攻击速度必须大于 0";
             return false;
         }
+
+        if (UseMode == ItemUseMode.Tool && EquipScene == null)
+        {
+            errorMessage = "工具类物品必须配置 EquipScene";
+            return false;
+        }
+
+        if (UseMode == ItemUseMode.Placeable && Prefab == null)
+        {
+            errorMessage = "可放置物品必须配置 Prefab";
+            return false;
+        }
         
         return true;
     }
@@ -145,6 +184,10 @@ public partial class ItemData : Resource
             desc += $"\n攻击速度: {AttackSpeed:P0}";
         if (IsConsumable && HealAmount > 0)
             desc += $"\n使用效果: 恢复 {HealAmount} 生命值";
+        if (UseMode == ItemUseMode.Tool && ToolAction != ToolActionType.None)
+            desc += $"\n工具行为: {ToolAction}";
+        if (UseMode == ItemUseMode.Placeable)
+            desc += "\n可放置";
         
         return desc;
     }
@@ -158,5 +201,20 @@ public partial class ItemData : Resource
                Type == ItemType.Equipment || 
                AttackPower > 0 || 
                DefensePower > 0;
+    }
+
+    public bool IsToolItem()
+    {
+        return UseMode == ItemUseMode.Tool;
+    }
+
+    public bool IsPlaceableItem()
+    {
+        return UseMode == ItemUseMode.Placeable && Prefab != null;
+    }
+
+    public bool IsConsumableItem()
+    {
+        return UseMode == ItemUseMode.Consumable || IsConsumable || (HasUseEffect && HealAmount > 0);
     }
 }

--- a/resources/items/ItemDatabase.cs
+++ b/resources/items/ItemDatabase.cs
@@ -59,7 +59,7 @@ public partial class ItemDatabase : Node
         _items.Clear();
         IsLoaded = false;
 
-        string itemsPath = "res://resources/items/";
+        string itemsPath = "res://Resources/Items/";
         
         // 检查目录是否存在
         if (!DirAccess.DirExistsAbsolute(itemsPath))

--- a/resources/items/axe.tres
+++ b/resources/items/axe.tres
@@ -1,0 +1,21 @@
+[gd_resource type="Resource" script_class="ItemData" format=3]
+
+[ext_resource type="Script" path="res://Resources/Items/ItemData.cs" id="1_itemdata"]
+[ext_resource type="Texture2D" path="res://Sprites/axe.png" id="2_icon"]
+[ext_resource type="PackedScene" path="res://Entities/Items/axe.tscn" id="3_scene"]
+
+[resource]
+script = ExtResource("1_itemdata")
+Id = "axe"
+Name = "Axe"
+Description = "一把基础斧头，可以砍树。"
+Icon = ExtResource("2_icon")
+Type = 3
+MaxStack = 1
+IsStackable = false
+AttackPower = 15
+UseCooldown = 0.1
+UseMode = 1
+ToolAction = 1
+EquipScene = ExtResource("3_scene")
+EquipOffset = Vector2(4, 0)

--- a/resources/items/table.tres
+++ b/resources/items/table.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" script_class="ItemData" format=3]
+
+[ext_resource type="Script" path="res://Resources/Items/ItemData.cs" id="1_itemdata"]
+[ext_resource type="Texture2D" path="res://Sprites/table0.png" id="2_icon"]
+[ext_resource type="PackedScene" path="res://Entities/Environment/table.tscn" id="3_prefab"]
+
+[resource]
+script = ExtResource("1_itemdata")
+Id = "table"
+Name = "Table"
+Description = "可放置的基础家具。"
+Icon = ExtResource("2_icon")
+Type = 6
+MaxStack = 10
+IsStackable = true
+UseMode = 2
+Prefab = ExtResource("3_prefab")


### PR DESCRIPTION
改动的核心在这些地方：

Resources/Items/ItemData.cs：给物品加了 UseMode、ToolAction、EquipScene、EquipOffset，把“这是工具还是可放置物”做成可配置数据。
Components/InventoryComponent.cs：加了初始物品配置和槽位读取接口，方便 UI 和玩家逻辑直接读取。
Entities/Player/Player.cs：加入当前激活槽位、动态装备工具、消费可消耗物、和 BuildingSystem 的联动。
Entities/Items/Weapon.cs 与 Entities/Environment/Tree.cs：把树木交互从 weapon is Axe 改成了按 ToolAction == Chop 判断。
Core/BuildingSystem.cs：新增放置成功/模式切换信号，让放置和背包扣除解耦。
UI/Inventory/GameInventoryUI.cs 与 UI/Inventory/game_inventory_ui.tscn：新增背包 UI 和 hotbar，并接到了 InventoryUpdated 和玩家当前选中槽位上。
Resources/Items/axe.tres、Resources/Items/table.tres：补了最小可用示例物品资源。
Entities/Player/player.tscn、basic.tscn：移除了玩家默认挂载的斧头，改为通过 inventory 驱动，并把 UI 实例接进主场景。