### PR TITLE
Refactor for multiplayer prep

### DIFF
--- a/Components/PlayerInputComponent.cs
+++ b/Components/PlayerInputComponent.cs
@@ -2,6 +2,8 @@ namespace AlongJourney.Components;
 
 using Godot;
 using AlongJourney.Entities;
+using AlongJourney.Entities.Player;
+using AlongJourney.Core;
 
 /// <summary>
 /// 玩家输入组件：负责读取 Input 并写入黑板
@@ -29,11 +31,24 @@ public partial class PlayerInputComponent : BaseComponent
             return;
         }
 
-        // 读取输入并写入黑板
-        Vector2 input = Input.GetVector("ui_left", "ui_right", "ui_up", "ui_down");
+        Player player = Owner as Player;
+        if (player != null && !player.CanHandleLocalInput())
+        {
+            return;
+        }
+
+        PlayerInputIntent intent = ReadLocalIntent(player);
         
         // 同时写入两个键以保持兼容性
-        Owner.SetBlackboardValue(Actor.BlackboardKeys.InputVector, input);
-        Owner.SetBlackboardValue(Actor.BlackboardKeys.MoveDirection, input);
+        Owner.SetBlackboardValue(Actor.BlackboardKeys.InputVector, intent.MoveDirection);
+        Owner.SetBlackboardValue(Actor.BlackboardKeys.MoveDirection, intent.MoveDirection);
+    }
+
+    private static PlayerInputIntent ReadLocalIntent(Player player)
+    {
+        // Current project has one keyboard/mouse input map. The player parameter
+        // keeps this boundary ready for per-device or peer-routed input sources.
+        Vector2 moveDirection = Input.GetVector("ui_left", "ui_right", "ui_up", "ui_down");
+        return new PlayerInputIntent(moveDirection);
     }
 }

--- a/Core/BuildingSystem.cs
+++ b/Core/BuildingSystem.cs
@@ -1,5 +1,6 @@
 using Godot;
 using System;
+using AlongJourney.Core;
 
 public partial class BuildingSystem : Node2D
 {
@@ -19,6 +20,8 @@ public partial class BuildingSystem : Node2D
 
     private Node2D _previewIllusion; // 预览的虚影
     private bool _isBuildingMode = false;
+    private int _activePlayerId = GameConstants.InvalidPlayerId;
+    private readonly WorldMutationService _worldMutations = new();
     public bool IsBuildingMode => _isBuildingMode;
     public PackedScene CurrentBuildingTarget => ObjectToPlace;
 
@@ -61,6 +64,11 @@ public partial class BuildingSystem : Node2D
     // 核心方法：设置当前要建造的物体
     public void SetBuildingTarget(PackedScene scene)
     {
+        SetBuildingTargetForPlayer(scene, GameConstants.InvalidPlayerId);
+    }
+
+    public void SetBuildingTargetForPlayer(PackedScene scene, int playerId)
+    {
         if (scene == null)
         {
             CancelBuildingMode();
@@ -74,6 +82,7 @@ public partial class BuildingSystem : Node2D
         }
 
         ObjectToPlace = scene;
+        _activePlayerId = playerId;
         Node instance = scene.Instantiate();
         
         if (instance is Node2D node2d)
@@ -100,6 +109,7 @@ public partial class BuildingSystem : Node2D
     {
         _isBuildingMode = false;
         ObjectToPlace = null;
+        _activePlayerId = GameConstants.InvalidPlayerId;
 
         if (_previewIllusion != null)
         {
@@ -130,15 +140,17 @@ public partial class BuildingSystem : Node2D
             return false;
         }
 
-        // 真正的实例化
-        Node2D newBuilding = ObjectToPlace.Instantiate<Node2D>();
-        
-        // 获取刚才计算好的吸附位置
-        newBuilding.GlobalPosition = _previewIllusion.GlobalPosition;
-        
-        // 将物体添加到场景中（通常添加到 Y-Sort 节点下，而不是 BuildingSystem 下）
-        // 这里假设 GroundLayer 的父节点是主要的 Y-Sort 容器
-        ObjectLayer.AddChild(newBuilding);
+        var request = new PlaceObjectRequest(
+            ObjectToPlace,
+            ObjectLayer,
+            _previewIllusion.GlobalPosition,
+            _activePlayerId);
+
+        if (!_worldMutations.TryPlaceObject(request, out var newBuilding))
+        {
+            return false;
+        }
+
         EmitSignal(SignalName.ObjectPlaced, ObjectToPlace, newBuilding.GlobalPosition);
 
         // 可选：放置后是否退出建造模式？

--- a/Core/GameConstants.cs
+++ b/Core/GameConstants.cs
@@ -3,4 +3,8 @@ namespace AlongJourney.Core;
 public static class GameConstants
 {
     public const string PlayerGroupName = "Player";
+    public const string LocalPlayerGroupName = "LocalPlayer";
+    public const int InvalidPlayerId = 0;
+    public const int DefaultLocalPlayerId = 1;
+    public const int KeyboardAndMouseDeviceId = -1;
 }

--- a/Core/GameManager.cs
+++ b/Core/GameManager.cs
@@ -9,6 +9,8 @@ using AlongJourney.Entities.Player;
 
 public partial class GameManager : Node
 {
+    public static GameManager Instance { get; private set; }
+
     [ExportGroup("Respawn Settings")]
     [Export] public float RespawnDelay = 3.0f;
 
@@ -20,20 +22,41 @@ public partial class GameManager : Node
     private Vector2 _spawnPosition;
     private uint _playerCollisionLayer;
     private uint _playerCollisionMask;
+    private int _cachedPlayerId = GameConstants.DefaultLocalPlayerId;
+    private bool _cachedIsLocalPlayer = true;
+    private int _cachedInputDeviceId = GameConstants.KeyboardAndMouseDeviceId;
     private bool _respawnInProgress;
     private List<InventoryComponent.SlotSnapshot> _cachedInventorySnapshot;
     private int _cachedActiveSlotIndex = -1;
 
+    public PlayerRegistry PlayerRegistry { get; } = new();
+    public LocalPlayerContext LocalPlayerContext { get; } = new();
+
     public override void _Ready()
     {
+        Instance = this;
         GetTree().NodeAdded += OnNodeAdded;
         GetTree().SceneChanged += OnSceneChanged;
         CallDeferred(nameof(TryInitializeFromScene));
     }
 
+    public override void _ExitTree()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
+        }
+
+        ClearPlayerSubscription();
+        PlayerRegistry.Clear();
+        LocalPlayerContext.Clear();
+    }
+
     private void OnSceneChanged()
     {
         ClearPlayerSubscription();
+        PlayerRegistry.Clear();
+        LocalPlayerContext.Clear();
         _respawnInProgress = false;
         _cachedInventorySnapshot = null;
         _cachedActiveSlotIndex = -1;
@@ -63,12 +86,46 @@ public partial class GameManager : Node
 
     private Player FindPlayer()
     {
-        return GetTree().GetFirstNodeInGroup(GameConstants.PlayerGroupName) as Player;
+        var localPlayer = PlayerRegistry.GetFirstLocalPlayer();
+        if (localPlayer != null)
+        {
+            return localPlayer;
+        }
+
+        foreach (var node in GetTree().GetNodesInGroup(GameConstants.LocalPlayerGroupName))
+        {
+            if (node is Player player && player.IsAlive)
+            {
+                return player;
+            }
+        }
+
+        foreach (var node in GetTree().GetNodesInGroup(GameConstants.PlayerGroupName))
+        {
+            if (node is Player player && player.IsAlive)
+            {
+                return player;
+            }
+        }
+
+        return null;
     }
 
     private void SetupPlayer(Player player)
     {
+        PlayerRegistry.Register(player);
+
+        if (player.IsLocalPlayer || !LocalPlayerContext.HasValidPlayer)
+        {
+            LocalPlayerContext.Bind(player);
+        }
+
         if (_currentPlayer == player)
+        {
+            return;
+        }
+
+        if (!player.IsLocalPlayer)
         {
             return;
         }
@@ -85,6 +142,9 @@ public partial class GameManager : Node
         _spawnPosition = ResolveSpawnPosition(player);
         _playerCollisionLayer = player.CollisionLayer;
         _playerCollisionMask = player.CollisionMask;
+        _cachedPlayerId = player.PlayerId;
+        _cachedIsLocalPlayer = player.IsLocalPlayer;
+        _cachedInputDeviceId = player.InputDeviceId;
 
         if (_playerScene == null)
         {
@@ -117,6 +177,7 @@ public partial class GameManager : Node
     {
         player.PlayerDied -= OnPlayerDied;
         _currentPlayer = player;
+        LocalPlayerContext.Bind(player);
         player.PlayerDied += OnPlayerDied;
     }
 
@@ -126,6 +187,7 @@ public partial class GameManager : Node
         {
             _currentPlayer.PlayerDied -= OnPlayerDied;
         }
+        LocalPlayerContext.ClearIf(_currentPlayer);
         _currentPlayer = null;
     }
 
@@ -141,6 +203,7 @@ public partial class GameManager : Node
         CacheInventoryState(player);
 
         // 先清理信号订阅，避免在删除过程中触发信号
+        PlayerRegistry.Unregister(player);
         ClearPlayerSubscription();
 
         float delay = RespawnDelay;
@@ -225,6 +288,11 @@ public partial class GameManager : Node
         playerNode.Name = "Player";
 
         Node parent = _playerParent ?? GetTree().CurrentScene ?? this;
+        if (playerNode is Player spawnedPlayer)
+        {
+            spawnedPlayer.ConfigureMultiplayerIdentity(_cachedPlayerId, _cachedIsLocalPlayer, _cachedInputDeviceId);
+        }
+
         parent.AddChild(playerNode);
 
         if (playerNode is Node2D node2D)
@@ -242,7 +310,10 @@ public partial class GameManager : Node
             player.SetHurtboxEnabled(true);
             RestoreInventoryState(player);
 
-            UpdatePhantomCameraFollowTarget(player);
+            if (player.IsLocalPlayer)
+            {
+                UpdatePhantomCameraFollowTarget(player);
+            }
         }
         else
         {

--- a/Core/LocalPlayerContext.cs
+++ b/Core/LocalPlayerContext.cs
@@ -1,0 +1,55 @@
+namespace AlongJourney.Core;
+
+using System;
+using Godot;
+using AlongJourney.Entities.Player;
+
+/// <summary>
+/// The local presentation context: UI, camera, and local input bind to this
+/// player. It is separate from the registry so future clients can each choose
+/// their own local player while the host owns the world simulation.
+/// </summary>
+public sealed class LocalPlayerContext
+{
+    public event Action<Player> LocalPlayerChanged;
+
+    public int LocalPlayerId { get; private set; } = GameConstants.DefaultLocalPlayerId;
+    public Player CurrentPlayer { get; private set; }
+
+    public bool HasValidPlayer =>
+        CurrentPlayer != null &&
+        GodotObject.IsInstanceValid(CurrentPlayer) &&
+        CurrentPlayer.IsInsideTree();
+
+    public void Bind(Player player)
+    {
+        if (player == null)
+        {
+            Clear();
+            return;
+        }
+
+        LocalPlayerId = player.PlayerId;
+        CurrentPlayer = player;
+        LocalPlayerChanged?.Invoke(CurrentPlayer);
+    }
+
+    public void ClearIf(Player player)
+    {
+        if (CurrentPlayer == player)
+        {
+            Clear();
+        }
+    }
+
+    public void Clear()
+    {
+        if (CurrentPlayer == null)
+        {
+            return;
+        }
+
+        CurrentPlayer = null;
+        LocalPlayerChanged?.Invoke(null);
+    }
+}

--- a/Core/PlayerInputIntent.cs
+++ b/Core/PlayerInputIntent.cs
@@ -1,0 +1,19 @@
+namespace AlongJourney.Core;
+
+using Godot;
+
+/// <summary>
+/// Local input intent for one player. Future multiplayer code can serialize this
+/// instead of exposing raw Godot input state to the simulation.
+/// </summary>
+public readonly struct PlayerInputIntent
+{
+    public static readonly PlayerInputIntent Empty = new(Vector2.Zero);
+
+    public PlayerInputIntent(Vector2 moveDirection)
+    {
+        MoveDirection = moveDirection;
+    }
+
+    public Vector2 MoveDirection { get; }
+}

--- a/Core/PlayerRegistry.cs
+++ b/Core/PlayerRegistry.cs
@@ -1,0 +1,102 @@
+namespace AlongJourney.Core;
+
+using System.Collections.Generic;
+using Godot;
+using AlongJourney.Entities.Player;
+
+/// <summary>
+/// Tracks players by stable local ids. This is intentionally network-free; peer
+/// ids and device routing can be layered on top later.
+/// </summary>
+public sealed class PlayerRegistry
+{
+    private readonly Dictionary<int, Player> _playersById = new();
+    private int _nextGeneratedId = GameConstants.DefaultLocalPlayerId;
+
+    public IReadOnlyDictionary<int, Player> PlayersById => _playersById;
+
+    public int Register(Player player)
+    {
+        if (player == null)
+        {
+            return GameConstants.InvalidPlayerId;
+        }
+
+        int playerId = player.PlayerId > GameConstants.InvalidPlayerId
+            ? player.PlayerId
+            : AllocatePlayerId();
+
+        _playersById[playerId] = player;
+        player.ConfigureMultiplayerIdentity(playerId, player.IsLocalPlayer, player.InputDeviceId);
+        _nextGeneratedId = Mathf.Max(_nextGeneratedId, playerId + 1);
+        return playerId;
+    }
+
+    public void Unregister(Player player)
+    {
+        if (player == null)
+        {
+            return;
+        }
+
+        if (_playersById.TryGetValue(player.PlayerId, out var registered) && registered == player)
+        {
+            _playersById.Remove(player.PlayerId);
+        }
+    }
+
+    public Player GetPlayer(int playerId)
+    {
+        return _playersById.TryGetValue(playerId, out var player) && IsPlayerValid(player)
+            ? player
+            : null;
+    }
+
+    public Player GetFirstLocalPlayer()
+    {
+        foreach (var player in GetPlayers())
+        {
+            if (player.IsLocalPlayer)
+            {
+                return player;
+            }
+        }
+
+        return null;
+    }
+
+    public List<Player> GetPlayers()
+    {
+        var players = new List<Player>(_playersById.Count);
+        foreach (var pair in _playersById)
+        {
+            if (IsPlayerValid(pair.Value))
+            {
+                players.Add(pair.Value);
+            }
+        }
+
+        return players;
+    }
+
+    public void Clear()
+    {
+        _playersById.Clear();
+        _nextGeneratedId = GameConstants.DefaultLocalPlayerId;
+    }
+
+    private int AllocatePlayerId()
+    {
+        while (_playersById.ContainsKey(_nextGeneratedId))
+        {
+            _nextGeneratedId++;
+        }
+
+        return _nextGeneratedId++;
+    }
+
+    private static bool IsPlayerValid(Player player)
+    {
+        return player != null && GodotObject.IsInstanceValid(player) && player.IsInsideTree();
+    }
+}

--- a/Core/WorldMutationService.cs
+++ b/Core/WorldMutationService.cs
@@ -1,0 +1,41 @@
+namespace AlongJourney.Core;
+
+using Godot;
+
+public readonly struct PlaceObjectRequest
+{
+    public PlaceObjectRequest(PackedScene scene, Node2D parent, Vector2 position, int requestedByPlayerId)
+    {
+        Scene = scene;
+        Parent = parent;
+        Position = position;
+        RequestedByPlayerId = requestedByPlayerId;
+    }
+
+    public PackedScene Scene { get; }
+    public Node2D Parent { get; }
+    public Vector2 Position { get; }
+    public int RequestedByPlayerId { get; }
+}
+
+/// <summary>
+/// Single entry point for world mutations. It is local and immediate today, but
+/// the call boundary matches future host-authoritative validation.
+/// </summary>
+public sealed class WorldMutationService
+{
+    public bool TryPlaceObject(PlaceObjectRequest request, out Node2D placedObject)
+    {
+        placedObject = null;
+
+        if (request.Scene == null || request.Parent == null)
+        {
+            return false;
+        }
+
+        placedObject = request.Scene.Instantiate<Node2D>();
+        placedObject.GlobalPosition = request.Position;
+        request.Parent.AddChild(placedObject);
+        return true;
+    }
+}

--- a/Entities/Enemies/Enemy.cs
+++ b/Entities/Enemies/Enemy.cs
@@ -33,14 +33,23 @@ public partial class Enemy : Actor
             return;
         _target = null;
 
-        var players = GetTree().GetNodesInGroup(GameConstants.PlayerGroupName);
+        var players = GameManager.Instance?.PlayerRegistry.GetPlayers();
+        if (players == null || players.Count == 0)
+        {
+            return;
+        }
 
+        float bestDistanceSquared = float.MaxValue;
         foreach (var player in players)
         {
             if (player is ITargetable targetable && targetable.IsAlive)
             {
-                _target = targetable;
-                break;
+                float distanceSquared = GlobalPosition.DistanceSquaredTo(targetable.GlobalPosition);
+                if (distanceSquared < bestDistanceSquared)
+                {
+                    bestDistanceSquared = distanceSquared;
+                    _target = targetable;
+                }
             }
         }
     }

--- a/Entities/Player/Player.cs
+++ b/Entities/Player/Player.cs
@@ -28,6 +28,9 @@ public partial class Player : Actor
 
     [Export] public Marker2D WeaponHolder;
     [Export] public int HotbarSize = 5;
+    [Export] public int PlayerId { get; private set; } = GameConstants.DefaultLocalPlayerId;
+    [Export] public bool IsLocalPlayer { get; private set; } = true;
+    [Export] public int InputDeviceId { get; private set; } = GameConstants.KeyboardAndMouseDeviceId;
 
     [ExportGroup("References")]
     [Export] private SelectionManager _selectionManager;
@@ -42,6 +45,7 @@ public partial class Player : Actor
 
         // 添加到 Player 组
         AddToGroup(GameConstants.PlayerGroupName);
+        UpdateLocalPlayerGroup();
 
         // 订阅 HealthComponent 信号
         if (HealthComponent != null)
@@ -92,7 +96,7 @@ public partial class Player : Actor
 
     public override void _UnhandledInput(InputEvent @event)
     {
-        if (!IsAlive || @event.IsEcho() || GetTree().Paused)
+        if (!CanHandleLocalInput() || !IsInputEventForThisPlayer(@event) || @event.IsEcho() || GetTree().Paused)
         {
             return;
         }
@@ -126,10 +130,51 @@ public partial class Player : Actor
             return;
         }
 
-        HandleWeaponAiming();
+        if (IsLocalPlayer)
+        {
+            HandleWeaponAiming();
+        }
 
         // MovementComponent 和 PlayerInputComponent 会自动处理移动
         base._PhysicsProcess(delta);
+    }
+
+    public void ConfigureMultiplayerIdentity(int playerId, bool isLocalPlayer, int inputDeviceId)
+    {
+        PlayerId = playerId <= GameConstants.InvalidPlayerId
+            ? GameConstants.DefaultLocalPlayerId
+            : playerId;
+        IsLocalPlayer = isLocalPlayer;
+        InputDeviceId = inputDeviceId;
+        UpdateLocalPlayerGroup();
+    }
+
+    public bool CanHandleLocalInput()
+    {
+        return IsAlive && IsLocalPlayer;
+    }
+
+    public bool IsInputEventForThisPlayer(InputEvent @event)
+    {
+        return InputDeviceId == GameConstants.KeyboardAndMouseDeviceId ||
+               @event.Device == InputDeviceId;
+    }
+
+    private void UpdateLocalPlayerGroup()
+    {
+        if (!IsInsideTree())
+        {
+            return;
+        }
+
+        if (IsLocalPlayer)
+        {
+            AddToGroup(GameConstants.LocalPlayerGroupName);
+        }
+        else
+        {
+            RemoveFromGroup(GameConstants.LocalPlayerGroupName);
+        }
     }
 
     private void HandleDied()
@@ -445,7 +490,7 @@ public partial class Player : Actor
 
         if (_activeItem != null && _activeItem.IsPlaceableItem())
         {
-            _buildingSystem?.SetBuildingTarget(_activeItem.Prefab);
+            _buildingSystem?.SetBuildingTargetForPlayer(_activeItem.Prefab, PlayerId);
             return;
         }
 

--- a/UI/Inventory/GameInventoryUI.cs
+++ b/UI/Inventory/GameInventoryUI.cs
@@ -164,7 +164,7 @@ public partial class GameInventoryUI : CanvasLayer
 
     private void RebindToCurrentPlayer()
     {
-        var nextPlayer = GetTree().GetFirstNodeInGroup(GameConstants.PlayerGroupName) as Player;
+        var nextPlayer = GameManager.Instance?.LocalPlayerContext.CurrentPlayer;
         if (_player == nextPlayer && IsBoundPlayerValid())
         {
             return;

--- a/basic.tscn
+++ b/basic.tscn
@@ -236,4 +236,4 @@ GroundLayer = NodePath("../GoundLayer")
 ObjectLayer = NodePath("../ObjectLayer")
 Subdivisions = 1
 
-[node name="GameInventoryUI" parent="." instance=ExtResource("13_ui")]
+[node name="GameInventoryUI" parent="." unique_id=2100186627 instance=ExtResource("13_ui")]

--- a/docs/MultiplayerArchitecture.md
+++ b/docs/MultiplayerArchitecture.md
@@ -1,0 +1,101 @@
+# Multiplayer-Ready Architecture
+
+This document describes the multiplayer-prep architecture. It does not describe a finished network implementation. The current target is still single-player behavior with explicit ownership boundaries that can later support a Terraria-like local host.
+
+## Goals
+
+- Keep the existing `Actor`, component, blackboard, and state machine gameplay model.
+- Stop treating the player as a global singleton.
+- Route local input through a player-owned intent boundary.
+- Bind UI and camera behavior to a local player context.
+- Send world changes through a single mutation boundary that can later become host-authoritative.
+
+## Core Concepts
+
+### Player Identity
+
+Each `Player` has:
+
+- `PlayerId`: stable local id. The default single-player id is `1`.
+- `IsLocalPlayer`: whether this process should drive input and presentation for this player.
+- `InputDeviceId`: reserved for later keyboard/gamepad/peer routing.
+
+These fields are local architecture metadata only. They are not network peer ids yet.
+
+### Player Registry
+
+`PlayerRegistry` tracks valid players by `PlayerId`. Game systems should ask the registry for player candidates instead of scanning the scene and assuming the first node in the `Player` group is the player.
+
+Current owner:
+
+- `GameManager.PlayerRegistry`
+
+Current users:
+
+- `GameManager` for respawn and local player setup.
+- `Enemy` for target selection.
+
+### Local Player Context
+
+`LocalPlayerContext` answers: "which player should this process present as local?"
+
+Current owner:
+
+- `GameManager.LocalPlayerContext`
+
+Current users:
+
+- `GameInventoryUI` binds to `LocalPlayerContext.CurrentPlayer`.
+- `GameManager` updates the Phantom Camera follow target only for the local player.
+
+Future client builds can bind a different local player without changing simulation entities.
+
+## Input Flow
+
+```mermaid
+flowchart LR
+    GodotInput[Godot Input] --> PlayerInputComponent[PlayerInputComponent]
+    PlayerInputComponent --> PlayerInputIntent[PlayerInputIntent]
+    PlayerInputIntent --> Blackboard[Actor Blackboard]
+    Blackboard --> MovementComponent[MovementComponent]
+    MovementComponent --> Actor[Actor MoveAndSlide]
+```
+
+`PlayerInputIntent` is the boundary between platform input and game simulation. It currently contains movement direction only. Future work can add attack, selected hotbar slot, aim position, build request, and interact request.
+
+`Player._UnhandledInput` still handles attack and hotbar actions directly, but now only for `IsLocalPlayer`. This keeps current gameplay working while making remote/non-local players passive from this process.
+
+## World Mutation Flow
+
+```mermaid
+flowchart LR
+    Player[Player] --> BuildingSystem[BuildingSystem]
+    BuildingSystem --> PlaceObjectRequest[PlaceObjectRequest]
+    PlaceObjectRequest --> WorldMutationService[WorldMutationService]
+    WorldMutationService --> ObjectLayer[ObjectLayer]
+```
+
+`WorldMutationService` is local and immediate today. Its purpose is to create a replaceable boundary for future host authority:
+
+- validate the requesting player
+- validate the requested object and position
+- assign stable world entity ids
+- replicate accepted changes to clients
+- persist accepted changes to world save data
+
+## Future LAN Host Route
+
+1. Add a session layer that maps `PlayerId` to peer/device ownership.
+2. Expand `PlayerInputIntent` into a serializable command object.
+3. Move attack, building, item pickup, and inventory changes behind command or mutation services.
+4. Make the host execute accepted commands and publish snapshots or events.
+5. Add stable ids for spawned objects, drops, enemies, and placed buildings.
+6. Add world/player save files using the same stable ids and item ids.
+
+## Current Non-Goals
+
+- No `MultiplayerAPI`, RPC, or synchronizer integration.
+- No client prediction or rollback.
+- No anti-cheat validation.
+- No persistent Terraria-style world save yet.
+- No split-screen or multiple local input devices yet.

--- a/docs/MultiplayerPrepMigration.md
+++ b/docs/MultiplayerPrepMigration.md
@@ -1,0 +1,82 @@
+# Multiplayer Prep Migration Notes
+
+This document records the multiplayer-prep refactor. The goal was to keep single-player behavior intact while removing the most important single-player assumptions.
+
+## Added Files
+
+- `Core/PlayerInputIntent.cs`: local player input command boundary.
+- `Core/PlayerRegistry.cs`: tracks players by stable local `PlayerId`.
+- `Core/LocalPlayerContext.cs`: owns the local presentation player for UI, camera, and input.
+- `Core/WorldMutationService.cs`: central entry point for world mutations such as building placement.
+
+## Changed Files
+
+### `Core/GameConstants.cs`
+
+Added constants for:
+
+- `LocalPlayerGroupName`
+- `InvalidPlayerId`
+- `DefaultLocalPlayerId`
+- `KeyboardAndMouseDeviceId`
+
+### `Entities/Player/Player.cs`
+
+Added multiplayer-prep metadata:
+
+- `PlayerId`
+- `IsLocalPlayer`
+- `InputDeviceId`
+
+Added local input guards so non-local players do not consume `_UnhandledInput` events in this process. Placeable item selection now calls `BuildingSystem.SetBuildingTargetForPlayer(...)` so build requests carry the initiating player id.
+
+### `Components/PlayerInputComponent.cs`
+
+The component now produces a `PlayerInputIntent` before writing movement to the actor blackboard. The current implementation still reads the existing Godot input map, but the call boundary is ready for per-device or peer-provided intent sources.
+
+### `Core/GameManager.cs`
+
+`GameManager` now owns:
+
+- `PlayerRegistry`
+- `LocalPlayerContext`
+- `GameManager.Instance`
+
+Player registration happens when `Player` nodes are discovered. Respawn keeps the current local player's identity, input device, inventory snapshot, collision settings, and camera binding.
+
+### `UI/Inventory/GameInventoryUI.cs`
+
+The inventory UI now binds to `GameManager.Instance.LocalPlayerContext.CurrentPlayer` instead of the first node in the `Player` group.
+
+### `Entities/Enemies/Enemy.cs`
+
+Enemies now query `PlayerRegistry` for target candidates and choose the closest valid live player. This removes the old dependency on scene tree group ordering.
+
+### `Core/BuildingSystem.cs`
+
+Building placement now creates a `PlaceObjectRequest` and passes it to `WorldMutationService.TryPlaceObject(...)`. Placement still happens locally and immediately.
+
+## Behavior Kept Intact
+
+- Single-player still defaults to `PlayerId = 1`.
+- Existing movement blackboard keys are still written for compatibility.
+- Existing attack, hotbar, inventory, and building flows remain local.
+- The Phantom Camera still follows the local player after respawn.
+
+## Remaining Single-Player Assumptions
+
+- `Player._UnhandledInput` still owns attack and hotbar commands directly.
+- `BuildingSystem` still uses the local mouse position for preview placement.
+- `SelectionManager` still uses the active viewport camera and mouse position.
+- `GameFlow` pause is still global via `GetTree().Paused`.
+- Item drops and tree drops still instantiate directly in the local scene.
+- There are no stable network/world entity ids yet.
+
+## Recommended Next Steps
+
+1. Expand `PlayerInputIntent` to include aim, attack, hotbar selection, build, cancel build, and interact commands.
+2. Move attack and inventory mutations behind authority-friendly services.
+3. Add a `WorldEntityId` for spawned actors, placed objects, and item drops.
+4. Create a session abstraction that maps `PlayerId` to peer id or local input device id.
+5. Add world save/load using stable entity ids and existing item ids.
+6. Add a small two-player local test scene before starting LAN networking.


### PR DESCRIPTION
#20 core architecture for multiplayer

- 新增 Core/PlayerRegistry.cs、Core/LocalPlayerContext.cs、Core/PlayerInputIntent.cs、Core/WorldMutationService.cs。
- Player 现在有 PlayerId、IsLocalPlayer、InputDeviceId，非本地玩家不会消费本机输入。
- GameManager 现在持有玩家注册表和本地玩家上下文，重生会保留玩家身份/输入设备/背包/相机绑定。
- GameInventoryUI 改为绑定本地玩家上下文，不再取第一个 Player。
- Enemy 改为从玩家注册表取候选目标，并选择最近的有效玩家。
- BuildingSystem 通过 WorldMutationService 执行放置请求，当前仍本地立即生效，但边界已准备给未来主机权威验证。
- 新增 docs/MultiplayerArchitecture.md 和 docs/MultiplayerPrepMigration.md。